### PR TITLE
Removed empty tag

### DIFF
--- a/src/bundle/Resources/config/services/strategies.yaml
+++ b/src/bundle/Resources/config/services/strategies.yaml
@@ -8,7 +8,7 @@ services:
         Ibexa\PersonalizationClient\Strategy\Storage\GroupItemStrategyInterface:
             tags:
                 - { name: ibexa.personalization.group_item.strategy }
-                -
+
         Ibexa\PersonalizationClient\Strategy\Credentials\ExportCredentialsStrategyInterface:
             tags:
                 - { name: ibexa.personalization.export_credentials.strategy }


### PR DESCRIPTION
Empty tag was added by mistake during the cross-merge between organizations.