### PR TITLE
Fixed random_int max value based on alphabet length

### DIFF
--- a/src/lib/Generator/SecureUniqueStringGenerator.php
+++ b/src/lib/Generator/SecureUniqueStringGenerator.php
@@ -36,7 +36,7 @@ final class SecureUniqueStringGenerator implements UniqueStringGeneratorInterfac
 
         $value = '';
         for ($i = 0; $i < $length; ++$i) {
-            $value .= $this->alphabet[random_int(0, $this->alphabetLength)];
+            $value .= $this->alphabet[random_int(0, $this->alphabetLength - 1)];
         }
 
         return $value;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1311](https://issues.ibexa.co/browse/IBX-1311)
| **Type**                                   | bug
| **Target Ibexa DXP version** | `v4.0`
| **BC breaks**                          | no
| **Doc needed**                       | no

Max value for random_int shouldn't be alphabet length because string characters are indexed from 0 to n-1 

Error in phpunit:

```
There was 1 error:

1) Ibexa\Tests\PersonalizationClient\Generator\SecureUniqueStringGeneratorTest::testGenerate
Uninitialized string offset: 62

/vendor/ibexa/personalization-client/src/lib/Generator/SecureUniqueStringGenerator.php:39
/vendor/ibexa/personalization-client/tests/lib/Generator/SecureUniqueStringGeneratorTest.php:43
```

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
