### PR TITLE
IBX-746: Implemented field types values normalizers

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -17,6 +17,7 @@ imports:
     - { resource: services/helpers.yaml }
     - { resource: services/http.yaml }
     - { resource: services/mappers.yaml }
+    - { resource: services/normalizers.yaml }
     - { resource: services/query_types.yaml }
     - { resource: services/response.yaml }
     - { resource: services/services.yaml }

--- a/src/bundle/Resources/config/services/normalizers.yaml
+++ b/src/bundle/Resources/config/services/normalizers.yaml
@@ -1,0 +1,78 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    _instanceof:
+        Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface:
+            tags:
+                - { name: 'ibexa.personalization.field_type.value.normalizer', priority: -100 }
+
+        Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\DestinationValueAwareInterface:
+            tags:
+                - { name: 'ibexa.personalization.field_type.destination.value.normalizer', priority: -100 }
+
+    Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcher:
+        arguments:
+            $normalizers: !tagged_iterator
+                tag: 'ibexa.personalization.field_type.destination.value.normalizer'
+
+    Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface:
+        '@Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcher'
+
+    Ibexa\PersonalizationClient\FieldType\ValueNormalizerDispatcher:
+        arguments:
+            $normalizers: !tagged_iterator
+                tag: 'ibexa.personalization.field_type.value.normalizer'
+
+    Ibexa\PersonalizationClient\FieldType\ValueNormalizerDispatcherInterface:
+        '@Ibexa\PersonalizationClient\FieldType\ValueNormalizerDispatcher'
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\AuthorNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\BinaryFileNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\CheckboxNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\CountryNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\DateNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\DateAndTimeNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\EmailAddressNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\FloatNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ImageNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ImageAssetNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\IntegerNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ISBNNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\KeywordNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\MapLocationNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\MediaNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RelationNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RelationListNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RichTextNormalizer:
+        tags:
+            - { name: monolog.logger, channel: ibexa-recommendation }
+        arguments:
+            $richHtml5Converter: '@ezrichtext.converter.output.xhtml5'
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TextBlockNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TextLineNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TimeNormalizer: ~
+
+    Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\UrlNormalizer: ~

--- a/src/bundle/Serializer/Normalizer/FieldType/AuthorNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/AuthorNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\Author\Value as AuthorValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/AuthorNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/AuthorNormalizer.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Author\Value as AuthorValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class AuthorNormalizer implements ValueNormalizerInterface
+{
+    /**
+     * @return array<string>
+     */
+    public function normalize(Value $value): array
+    {
+        if (!$value instanceof AuthorValue) {
+            throw new InvalidArgumentType('$value', AuthorValue::class, $value);
+        }
+
+        $authors = [];
+
+        /** @var \eZ\Publish\Core\FieldType\Author\Author $author */
+        foreach ($value->authors as $author) {
+            $authors[] = $author->name;
+        }
+
+        return $authors;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof AuthorValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/AuthorNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/AuthorNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Author\Value as AuthorValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Author\Value as AuthorValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\BinaryFile\Value as BinaryFileValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\BinaryFile\Value as BinaryFileValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\BinaryFile\Value as BinaryFileValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class BinaryFileNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): ?string
+    {
+        if (!$value instanceof BinaryFileValue) {
+            throw new InvalidArgumentType('$value', BinaryFileValue::class);
+        }
+
+        return $value->uri;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof BinaryFileValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\BinaryFile\Value as BinaryFileValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Checkbox\Value as CheckboxValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Checkbox\Value as CheckboxValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\Checkbox\Value as CheckboxValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Checkbox\Value as CheckboxValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class CheckboxNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): bool
+    {
+        if (!$value instanceof CheckboxValue) {
+            throw new InvalidArgumentType('$value', CheckboxValue::class);
+        }
+
+        return $value->bool;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof CheckboxValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/CountryNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/CountryNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Country\Value as CountryValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Country\Value as CountryValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/CountryNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/CountryNormalizer.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Country\Value as CountryValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class CountryNormalizer implements ValueNormalizerInterface
+{
+    /**
+     * @return array<string>
+     */
+    public function normalize(Value $value): array
+    {
+        if (!$value instanceof CountryValue) {
+            throw new InvalidArgumentType('$value', CountryValue::class);
+        }
+
+        return array_column($value->countries, 'Name');
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof CountryValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/CountryNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/CountryNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\Country\Value as CountryValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizer.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\DateAndTime\Value as DateAndTimeValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class DateAndTimeNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): ?string
+    {
+        if (!$value instanceof DateAndTimeValue) {
+            throw new InvalidArgumentType('$value', DateAndTimeValue::class);
+        }
+
+        $dateTime = $value->value;
+        if (null !== $dateTime) {
+            return $dateTime->format($value->stringFormat);
+        }
+
+        return null;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof DateAndTimeValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\DateAndTime\Value as DateAndTimeValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\DateAndTime\Value as DateAndTimeValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\DateAndTime\Value as DateAndTimeValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizer.php
@@ -21,9 +21,8 @@ final class DateAndTimeNormalizer implements ValueNormalizerInterface
             throw new InvalidArgumentType('$value', DateAndTimeValue::class);
         }
 
-        $dateTime = $value->value;
-        if (null !== $dateTime) {
-            return $dateTime->format($value->stringFormat);
+        if (null !== $value->value) {
+            return (string) $value;
         }
 
         return null;

--- a/src/bundle/Serializer/Normalizer/FieldType/DateNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/DateNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Date\Value as DateValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Date\Value as DateValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/DateNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/DateNormalizer.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Date\Value as DateValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class DateNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): ?string
+    {
+        if (!$value instanceof DateValue) {
+            throw new InvalidArgumentType('$value', DateValue::class);
+        }
+
+        $date = $value->date;
+        if (null !== $date) {
+            return $date->format($value->stringFormat);
+        }
+
+        return null;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof DateValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/DateNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/DateNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\Date\Value as DateValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/DateNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/DateNormalizer.php
@@ -21,9 +21,8 @@ final class DateNormalizer implements ValueNormalizerInterface
             throw new InvalidArgumentType('$value', DateValue::class);
         }
 
-        $date = $value->date;
-        if (null !== $date) {
-            return $date->format($value->stringFormat);
+        if (null !== $value->date) {
+            return (string) $value;
         }
 
         return null;

--- a/src/bundle/Serializer/Normalizer/FieldType/EmailAddressNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/EmailAddressNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\EmailAddress\Value as EmailAddressValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\EmailAddress\Value as EmailAddressValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/EmailAddressNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/EmailAddressNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\EmailAddress\Value as EmailAddressValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/EmailAddressNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/EmailAddressNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\EmailAddress\Value as EmailAddressValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class EmailAddressNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): string
+    {
+        if (!$value instanceof EmailAddressValue) {
+            throw new InvalidArgumentType('$value', EmailAddressValue::class);
+        }
+
+        return $value->email;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof EmailAddressValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/FloatNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/FloatNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Float\Value as FloatValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Float\Value as FloatValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/FloatNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/FloatNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Float\Value as FloatValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class FloatNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): ?float
+    {
+        if (!$value instanceof FloatValue) {
+            throw new InvalidArgumentType('$value', FloatValue::class);
+        }
+
+        return $value->value;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof FloatValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/FloatNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/FloatNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\Float\Value as FloatValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/ISBNNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/ISBNNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\ISBN\Value as ISBNValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class ISBNNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): string
+    {
+        if (!$value instanceof ISBNValue) {
+            throw new InvalidArgumentType('$value', ISBNValue::class);
+        }
+
+        return $value->isbn;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof ISBNValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/ISBNNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/ISBNNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\ISBN\Value as ISBNValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/ISBNNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/ISBNNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\ISBN\Value as ISBNValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\ISBN\Value as ISBNValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\ImageAsset\Value as ImageAssetValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\ImageAsset\Value as ImageAssetValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;

--- a/src/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizer.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\ImageAsset\Value as ImageAssetValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;
+
+final class ImageAssetNormalizer implements ValueNormalizerInterface
+{
+    private DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer;
+
+    public function __construct(DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer)
+    {
+        $this->destinationContentNormalizer = $destinationContentNormalizer;
+    }
+
+    public function normalize(Value $value): ?string
+    {
+        if (!$value instanceof ImageAssetValue) {
+            throw new InvalidArgumentType('$value', ImageAssetValue::class);
+        }
+
+        $destinationContentId = $value->destinationContentId;
+        if (null !== $destinationContentId) {
+            $imageUri = $this->destinationContentNormalizer->dispatch((int) $destinationContentId);
+            if (is_string($imageUri)) {
+                return $imageUri;
+            }
+        }
+
+        return null;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof ImageAssetValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\ImageAsset\Value as ImageAssetValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;

--- a/src/bundle/Serializer/Normalizer/FieldType/ImageNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/ImageNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\DestinationValueAwareInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/ImageNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/ImageNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\DestinationValueAwareInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/ImageNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/ImageNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\DestinationValueAwareInterface;
+
+final class ImageNormalizer implements DestinationValueAwareInterface
+{
+    public function normalize(Value $value): ?string
+    {
+        if (!$value instanceof ImageValue) {
+            throw new InvalidArgumentType('$value', ImageValue::class);
+        }
+
+        return $value->uri;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof ImageValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/IntegerNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/IntegerNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Integer\Value as IntegerValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class IntegerNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): ?int
+    {
+        if (!$value instanceof IntegerValue) {
+            throw new InvalidArgumentType('$value', IntegerValue::class);
+        }
+
+        return $value->value;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof IntegerValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/IntegerNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/IntegerNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Integer\Value as IntegerValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Integer\Value as IntegerValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/IntegerNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/IntegerNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\Integer\Value as IntegerValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/KeywordNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/KeywordNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Keyword\Value as KeywordValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Keyword\Value as KeywordValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/KeywordNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/KeywordNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\Keyword\Value as KeywordValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/KeywordNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/KeywordNormalizer.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Keyword\Value as KeywordValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class KeywordNormalizer implements ValueNormalizerInterface
+{
+    /**
+     * @return array<string>
+     */
+    public function normalize(Value $value): array
+    {
+        if (!$value instanceof KeywordValue) {
+            throw new InvalidArgumentType('$value', KeywordValue::class);
+        }
+
+        return $value->values;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof KeywordValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/MapLocationNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/MapLocationNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\MapLocation\Value as MapLocationValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class MapLocationNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): ?string
+    {
+        if (!$value instanceof MapLocationValue) {
+            throw new InvalidArgumentType('$value', MapLocationValue::class);
+        }
+
+        return $value->address;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof MapLocationValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/MapLocationNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/MapLocationNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\MapLocation\Value as MapLocationValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\MapLocation\Value as MapLocationValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/MapLocationNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/MapLocationNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\MapLocation\Value as MapLocationValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/MediaNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/MediaNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Media\Value as MediaFileValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class MediaNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): ?string
+    {
+        if (!$value instanceof MediaFileValue) {
+            throw new InvalidArgumentType('$value', MediaFileValue::class);
+        }
+
+        return $value->uri;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof MediaFileValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/MediaNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/MediaNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\Media\Value as MediaValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/MediaNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/MediaNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Media\Value as MediaValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Media\Value as MediaValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/MediaNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/MediaNormalizer.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Media\Value as MediaFileValue;
+use eZ\Publish\Core\FieldType\Media\Value as MediaValue;
 use eZ\Publish\SPI\Exception\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
@@ -17,8 +17,8 @@ final class MediaNormalizer implements ValueNormalizerInterface
 {
     public function normalize(Value $value): ?string
     {
-        if (!$value instanceof MediaFileValue) {
-            throw new InvalidArgumentType('$value', MediaFileValue::class);
+        if (!$value instanceof MediaValue) {
+            throw new InvalidArgumentType('$value', MediaValue::class);
         }
 
         return $value->uri;
@@ -26,6 +26,6 @@ final class MediaNormalizer implements ValueNormalizerInterface
 
     public function supportsValue(Value $value): bool
     {
-        return $value instanceof MediaFileValue;
+        return $value instanceof MediaValue;
     }
 }

--- a/src/bundle/Serializer/Normalizer/FieldType/RelationListNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/RelationListNormalizer.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\RelationList\Value as RelationListValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;
+
+final class RelationListNormalizer implements ValueNormalizerInterface
+{
+    private DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer;
+
+    public function __construct(DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer)
+    {
+        $this->destinationContentNormalizer = $destinationContentNormalizer;
+    }
+
+    /**
+     * @return array<array<scalar|null>|scalar|null>
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function normalize(Value $value): array
+    {
+        if (!$value instanceof RelationListValue) {
+            throw new InvalidArgumentType('$value', RelationListValue::class);
+        }
+
+        $fields = [];
+        foreach ($value->destinationContentIds as $destinationContentId) {
+            $normalizedValue = $this->destinationContentNormalizer->dispatch($destinationContentId);
+            if (null !== $normalizedValue) {
+                $fields[] = $normalizedValue;
+            }
+        }
+
+        return $fields;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof RelationListValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/RelationListNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/RelationListNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\RelationList\Value as RelationListValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;

--- a/src/bundle/Serializer/Normalizer/FieldType/RelationListNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/RelationListNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\RelationList\Value as RelationListValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\RelationList\Value as RelationListValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;

--- a/src/bundle/Serializer/Normalizer/FieldType/RelationNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/RelationNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Relation\Value as RelationValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Relation\Value as RelationValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;

--- a/src/bundle/Serializer/Normalizer/FieldType/RelationNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/RelationNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\Relation\Value as RelationValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;

--- a/src/bundle/Serializer/Normalizer/FieldType/RelationNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/RelationNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Relation\Value as RelationValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;
+
+final class RelationNormalizer implements ValueNormalizerInterface
+{
+    private DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer;
+
+    public function __construct(DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer)
+    {
+        $this->destinationContentNormalizer = $destinationContentNormalizer;
+    }
+
+    public function normalize(Value $value)
+    {
+        if (!$value instanceof RelationValue) {
+            throw new InvalidArgumentType('$value', RelationValue::class);
+        }
+
+        $destinationContentId = $value->destinationContentId;
+        if (null !== $destinationContentId) {
+            return $this->destinationContentNormalizer->dispatch((int) $destinationContentId);
+        }
+
+        return null;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof RelationValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/RichTextNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/RichTextNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value as RichTextValue;
+use EzSystems\EzPlatformRichText\eZ\RichText\Converter;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+final class RichTextNormalizer implements ValueNormalizerInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    private Converter $richHtml5Converter;
+
+    public function __construct(
+        Converter $richHtml5Converter,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->richHtml5Converter = $richHtml5Converter;
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function normalize(Value $value): ?string
+    {
+        if (!$value instanceof RichTextValue) {
+            throw new InvalidArgumentType('$value', RichTextValue::class);
+        }
+
+        $convertedString = $this->richHtml5Converter->convert($value->xml)->saveHTML();
+
+        if (false === $convertedString) {
+            $this->logger->warning('Failed to convert xml: ' . $value);
+
+            return null;
+        }
+
+        return $convertedString;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof RichTextValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/RichTextNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/RichTextNormalizer.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value as RichTextValue;
 use EzSystems\EzPlatformRichText\eZ\RichText\Converter;

--- a/src/bundle/Serializer/Normalizer/FieldType/TextBlockNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/TextBlockNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\TextBlock\Value as TextBlockValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\TextBlock\Value as TextBlockValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/TextBlockNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/TextBlockNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\TextBlock\Value as TextBlockValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/TextBlockNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/TextBlockNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\TextBlock\Value as TextBlockValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class TextBlockNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): string
+    {
+        if (!$value instanceof TextBlockValue) {
+            throw new InvalidArgumentType('$value', TextBlockValue::class);
+        }
+
+        return $value->text;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof TextBlockValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/TextLineNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/TextLineNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/TextLineNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/TextLineNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/TextLineNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/TextLineNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class TextLineNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): string
+    {
+        if (!$value instanceof TextLineValue) {
+            throw new InvalidArgumentType('$value', TextLineValue::class);
+        }
+
+        return $value->text;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof TextLineValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/TimeNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/TimeNormalizer.php
@@ -8,9 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use DateTime;
-use eZ\Publish\Core\FieldType\Time\Value as TimeValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Time\Value as TimeValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/TimeNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/TimeNormalizer.php
@@ -10,7 +10,7 @@ namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use DateTime;
 use eZ\Publish\Core\FieldType\Time\Value as TimeValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/TimeNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/TimeNormalizer.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use DateTime;
+use eZ\Publish\Core\FieldType\Time\Value as TimeValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class TimeNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): ?string
+    {
+        if (!$value instanceof TimeValue) {
+            throw new InvalidArgumentType('$value', TimeValue::class);
+        }
+
+        $time = $value->time;
+        if (null !== $time) {
+            $dateTime = new DateTime("@{$time}");
+
+            return $dateTime->format($value->stringFormat);
+        }
+
+        return null;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof TimeValue;
+    }
+}

--- a/src/bundle/Serializer/Normalizer/FieldType/TimeNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/TimeNormalizer.php
@@ -22,11 +22,8 @@ final class TimeNormalizer implements ValueNormalizerInterface
             throw new InvalidArgumentType('$value', TimeValue::class);
         }
 
-        $time = $value->time;
-        if (null !== $time) {
-            $dateTime = new DateTime("@{$time}");
-
-            return $dateTime->format($value->stringFormat);
+        if (null !== $value->time) {
+            return (string) $value;
         }
 
         return null;

--- a/src/bundle/Serializer/Normalizer/FieldType/UrlNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/UrlNormalizer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
-use eZ\Publish\Core\FieldType\Url\Value as UrlValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Url\Value as UrlValue;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/UrlNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/UrlNormalizer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
 use eZ\Publish\Core\FieldType\Url\Value as UrlValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 

--- a/src/bundle/Serializer/Normalizer/FieldType/UrlNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/UrlNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Url\Value as UrlValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class UrlNormalizer implements ValueNormalizerInterface
+{
+    public function normalize(Value $value): ?string
+    {
+        if (!$value instanceof UrlValue) {
+            throw new InvalidArgumentType('$value', UrlValue::class);
+        }
+
+        return $value->link;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof UrlValue;
+    }
+}

--- a/src/contracts/Serializer/Normalizer/DestinationValueAwareInterface.php
+++ b/src/contracts/Serializer/Normalizer/DestinationValueAwareInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer;
+
+interface DestinationValueAwareInterface extends ValueNormalizerInterface
+{
+}

--- a/src/contracts/Serializer/Normalizer/ValueNormalizerInterface.php
+++ b/src/contracts/Serializer/Normalizer/ValueNormalizerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer;
+
+use eZ\Publish\SPI\FieldType\Value;
+
+interface ValueNormalizerInterface
+{
+    /**
+     * @return array<scalar|null>|scalar|null
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function normalize(Value $value);
+
+    public function supportsValue(Value $value): bool;
+}

--- a/src/lib/Exception/ValueNormalizerNotFoundException.php
+++ b/src/lib/Exception/ValueNormalizerNotFoundException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\PersonalizationClient\Exception;
+
+use eZ\Publish\SPI\FieldType\Value;
+use EzSystems\EzRecommendationClient\Exception\EzRecommendationException;
+use RuntimeException;
+use Throwable;
+
+final class ValueNormalizerNotFoundException extends RuntimeException implements EzRecommendationException
+{
+    public function __construct(Value $value, int $code = 0, Throwable $previous = null)
+    {
+        parent::__construct(
+            sprintf('ValueNormalizer not found for field type value: %s.', get_class($value)),
+            $code,
+            $previous
+        );
+    }
+}

--- a/src/lib/FieldType/DestinationContentNormalizerDispatcher.php
+++ b/src/lib/FieldType/DestinationContentNormalizerDispatcher.php
@@ -25,13 +25,13 @@ final class DestinationContentNormalizerDispatcher implements DestinationContent
      * @param iterable<\Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\DestinationValueAwareInterface> $normalizers
      */
     public function __construct(
-        iterable $normalizers,
         ContentService $contentService,
-        Repository $repository
+        Repository $repository,
+        iterable $normalizers
     ) {
-        $this->normalizers = $normalizers;
         $this->contentService = $contentService;
         $this->repository = $repository;
+        $this->normalizers = $normalizers;
     }
 
     public function dispatch(int $destinationContentId)

--- a/src/lib/FieldType/DestinationContentNormalizerDispatcher.php
+++ b/src/lib/FieldType/DestinationContentNormalizerDispatcher.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\PersonalizationClient\FieldType;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Content;
+
+final class DestinationContentNormalizerDispatcher implements DestinationContentNormalizerDispatcherInterface
+{
+    /** @var iterable<\Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\DestinationValueAwareInterface> */
+    private iterable $normalizers;
+
+    private ContentService $contentService;
+
+    private Repository $repository;
+
+    /**
+     * @param iterable<\Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\DestinationValueAwareInterface> $normalizers
+     */
+    public function __construct(
+        iterable $normalizers,
+        ContentService $contentService,
+        Repository $repository
+    ) {
+        $this->normalizers = $normalizers;
+        $this->contentService = $contentService;
+        $this->repository = $repository;
+    }
+
+    public function dispatch(int $destinationContentId)
+    {
+        $fields = $this->getContent($destinationContentId)->getFields();
+        foreach ($fields as $field) {
+            foreach ($this->normalizers as $normalizer) {
+                $value = $field->value;
+                if ($normalizer->supportsValue($value)) {
+                    return $normalizer->normalize($value);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function getContent(int $contentId): Content
+    {
+        return $this->repository->sudo(
+            function () use ($contentId): Content {
+                return $this->contentService->loadContent($contentId);
+            }
+        );
+    }
+}

--- a/src/lib/FieldType/DestinationContentNormalizerDispatcher.php
+++ b/src/lib/FieldType/DestinationContentNormalizerDispatcher.php
@@ -51,10 +51,6 @@ final class DestinationContentNormalizerDispatcher implements DestinationContent
 
     private function getContent(int $contentId): Content
     {
-        return $this->repository->sudo(
-            function () use ($contentId): Content {
-                return $this->contentService->loadContent($contentId);
-            }
-        );
+        return $this->repository->sudo(fn() => $this->contentService->loadContent($contentId));
     }
 }

--- a/src/lib/FieldType/DestinationContentNormalizerDispatcher.php
+++ b/src/lib/FieldType/DestinationContentNormalizerDispatcher.php
@@ -51,6 +51,6 @@ final class DestinationContentNormalizerDispatcher implements DestinationContent
 
     private function getContent(int $contentId): Content
     {
-        return $this->repository->sudo(fn() => $this->contentService->loadContent($contentId));
+        return $this->repository->sudo(fn () => $this->contentService->loadContent($contentId));
     }
 }

--- a/src/lib/FieldType/DestinationContentNormalizerDispatcherInterface.php
+++ b/src/lib/FieldType/DestinationContentNormalizerDispatcherInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\PersonalizationClient\FieldType;
+
+/**
+ * @internal
+ */
+interface DestinationContentNormalizerDispatcherInterface
+{
+    /**
+     * @return array<scalar|null>|scalar|null
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function dispatch(int $destinationContentId);
+}

--- a/src/lib/FieldType/ValueNormalizerDispatcher.php
+++ b/src/lib/FieldType/ValueNormalizerDispatcher.php
@@ -37,8 +37,8 @@ final class ValueNormalizerDispatcher implements ValueNormalizerDispatcherInterf
 
     public function supportsNormalizer(Value $value): bool
     {
-        foreach ($this->normalizers as $parser) {
-            if ($parser->supportsValue($value)) {
+        foreach ($this->normalizers as $normalizer) {
+            if ($normalizer->supportsValue($value)) {
                 return true;
             }
         }

--- a/src/lib/FieldType/ValueNormalizerDispatcher.php
+++ b/src/lib/FieldType/ValueNormalizerDispatcher.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\PersonalizationClient\FieldType;
+
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\PersonalizationClient\Exception\ValueNormalizerNotFoundException;
+
+final class ValueNormalizerDispatcher implements ValueNormalizerDispatcherInterface
+{
+    /** @var iterable<\Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface> */
+    private iterable $normalizers;
+
+    /**
+     * @param iterable<\Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface> $normalizers
+     */
+    public function __construct(iterable $normalizers)
+    {
+        $this->normalizers = $normalizers;
+    }
+
+    public function dispatch(Value $value)
+    {
+        foreach ($this->normalizers as $parser) {
+            if ($parser->supportsValue($value)) {
+                return $parser->normalize($value);
+            }
+        }
+
+        throw new ValueNormalizerNotFoundException($value);
+    }
+
+    public function supportsNormalizer(Value $value): bool
+    {
+        foreach ($this->normalizers as $parser) {
+            if ($parser->supportsValue($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/lib/FieldType/ValueNormalizerDispatcherInterface.php
+++ b/src/lib/FieldType/ValueNormalizerDispatcherInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\PersonalizationClient\FieldType;
+
+use eZ\Publish\SPI\FieldType\Value;
+
+/**
+ * @internal
+ */
+interface ValueNormalizerDispatcherInterface
+{
+    /**
+     * @return array<scalar|null>|scalar|null
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function dispatch(Value $value);
+
+    public function supportsNormalizer(Value $value): bool;
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/AbstractDestinationContentNormalizerTestCase.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/AbstractDestinationContentNormalizerTestCase.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;
+
+abstract class AbstractDestinationContentNormalizerTestCase extends AbstractValueNormalizerTestCase
+{
+    /** @var \Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject */
+    protected DestinationContentNormalizerDispatcherInterface $destinationContentNormalizerDispatcher;
+
+    protected function setUp(): void
+    {
+        $this->destinationContentNormalizerDispatcher = $this->createMock(DestinationContentNormalizerDispatcherInterface::class);
+    }
+
+    /**
+     * @param array<array<int|string|null>> $valuesMap
+     */
+    protected function configureDestinationContentNormalizerToReturnExpectedValue(array $valuesMap): void
+    {
+        $this->destinationContentNormalizerDispatcher
+            ->expects(self::atLeastOnce())
+            ->method('dispatch')
+            ->willReturnMap($valuesMap);
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/AbstractValueNormalizerTestCase.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/AbstractValueNormalizerTestCase.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
 
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\Core\FieldType\Null\Value as NullValue;
-use eZ\Publish\SPI\Exception\InvalidArgumentType;
 use eZ\Publish\SPI\FieldType\Value;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 use PHPUnit\Framework\TestCase;

--- a/tests/bundle/Serializer/Normalizer/FieldType/AbstractValueNormalizerTestCase.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/AbstractValueNormalizerTestCase.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Null\Value as NullValue;
+use eZ\Publish\SPI\Exception\InvalidArgumentType;
+use eZ\Publish\SPI\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractValueNormalizerTestCase extends TestCase
+{
+    abstract protected function getNormalizer(): ValueNormalizerInterface;
+
+    abstract protected function getValue(): Value;
+
+    protected function testSupportsValue(): void
+    {
+        $normalizer = $this->getNormalizer();
+
+        self::assertTrue($normalizer->supportsValue($this->getValue()));
+        self::assertFalse($normalizer->supportsValue(new NullValue()));
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    protected function testThrowExceptionWhenValueIsInvalidType(): void
+    {
+        $this->expectException(InvalidArgumentType::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Argument \'$value\' is invalid: Received \'%s\' instead of expected value of type \'%s\'',
+                NullValue::class,
+                get_class($this->getValue())
+            )
+        );
+        $this->getNormalizer()->normalize(new NullValue());
+    }
+
+    /**
+     * @param mixed $expected
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    protected function testNormalize($expected, Value $value): void
+    {
+        self::assertEquals(
+            $expected,
+            $this->getNormalizer()->normalize($value)
+        );
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/AuthorNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/AuthorNormalizerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Author\Author as CoreAuthor;
+use eZ\Publish\Core\FieldType\Author\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\AuthorNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class AuthorNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @param array<string> $expected
+
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(array $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  array<string>,
+     *  \eZ\Publish\Core\FieldType\Author\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            ['foo', 'bar'],
+            new Value(
+                [
+                    new CoreAuthor(
+                        [
+                            'id' => 1,
+                            'name' => 'foo',
+                            'email' => 'foo@link.invalid',
+                        ]
+                    ),
+                    new CoreAuthor(
+                        [
+                            'id' => 2,
+                            'name' => 'bar',
+                            'email' => 'bar@link.invalid',
+                        ]
+                    ),
+                ]
+            ),
+        ];
+
+        yield [
+            [],
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new AuthorNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/AuthorNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/AuthorNormalizerTest.php
@@ -13,6 +13,9 @@ use eZ\Publish\Core\FieldType\Author\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\AuthorNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\AuthorNormalizer
+ */
 final class AuthorNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/AuthorNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/AuthorNormalizerTest.php
@@ -22,7 +22,6 @@ final class AuthorNormalizerTest extends AbstractValueNormalizerTestCase
      * @dataProvider provideDataForTestNormalize
      *
      * @param array<string> $expected
-
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */

--- a/tests/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizerTest.php
@@ -19,7 +19,6 @@ final class BinaryFileNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**
      * @dataProvider provideDataForTestNormalize
-
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */

--- a/tests/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\BinaryFile\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\BinaryFileNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class BinaryFileNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?string,
+     *  \eZ\Publish\Core\FieldType\BinaryFile\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            'public/var/test/1/2/3/4/5/file.invalid',
+            new Value(
+                [
+                    'id' => 1,
+                    'inputUri' => 'storage/file.invalid',
+                    'fileName' => 'file.invalid',
+                    'fileSize' => 123456,
+                    'mimeType' => 'image/png',
+                    'uri' => 'public/var/test/1/2/3/4/5/file.invalid',
+                    'downloadCount' => 1,
+                ]
+            ),
+        ];
+
+        yield [
+            null,
+            new Value(
+                [
+                    'id' => null,
+                    'inputUri' => null,
+                    'fileName' => null,
+                    'fileSize' => null,
+                    'mimeType' => null,
+                    'uri' => null,
+                    'downloadCount' => null,
+                ]
+            ),
+        ];
+
+        yield [
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new BinaryFileNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/BinaryFileNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\BinaryFile\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\BinaryFileNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\BinaryFileNormalizer
+ */
 final class BinaryFileNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizerTest.php
@@ -19,7 +19,6 @@ final class CheckboxNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**
      * @dataProvider provideDataForTestNormalize
-
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */

--- a/tests/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Checkbox\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\CheckboxNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class CheckboxNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(bool $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  bool,
+     *  \eZ\Publish\Core\FieldType\Checkbox\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            false,
+            new Value(),
+        ];
+
+        yield [
+            true,
+            new Value(true),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new CheckboxNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/CheckboxNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\Checkbox\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\CheckboxNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\CheckboxNormalizer
+ */
 final class CheckboxNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/CountryNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/CountryNormalizerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Country\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\CountryNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class CountryNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @param array<string> $expected
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(array $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  array<string>,
+     *  \eZ\Publish\Core\FieldType\Country\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            ['Japan', 'Poland', 'France'],
+            new Value(
+                [
+                    'JP' => [
+                        'Name' => 'Japan',
+                        'Alpha2' => 'JP',
+                        'Alpha3' => 'JPN',
+                        'IDC' => 81,
+                    ],
+                    'PL' => [
+                        'Name' => 'Poland',
+                        'Alpha2' => 'PL',
+                        'Alpha3' => 'POL',
+                        'IDC' => 82,
+                    ],
+                    'FR' => [
+                        'Name' => 'France',
+                        'Alpha2' => 'FR',
+                        'Alpha3' => 'FRA',
+                        'IDC' => 83,
+                    ],
+                ]
+            ),
+        ];
+
+        yield [
+            [],
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new CountryNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/CountryNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/CountryNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\Country\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\CountryNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\CountryNormalizer
+ */
 final class CountryNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizerTest.php
@@ -13,6 +13,9 @@ use eZ\Publish\Core\FieldType\DateAndTime\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\DateAndTimeNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\DateAndTimeNormalizer
+ */
 final class DateAndTimeNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/DateAndTimeNormalizerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use DateTime;
+use eZ\Publish\Core\FieldType\DateAndTime\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\DateAndTimeNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class DateAndTimeNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?string,
+     *  \eZ\Publish\Core\FieldType\DateAndTime\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            '1609491600',
+            new Value(new DateTime('2021-01-01 09:00:00')),
+        ];
+
+        yield [
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new DateAndTimeNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/DateNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/DateNormalizerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use DateTime;
+use eZ\Publish\Core\FieldType\Date\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\DateNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class DateNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?string,
+     *  \eZ\Publish\Core\FieldType\Date\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            'Friday 01 January 2021',
+            new Value(new DateTime('2021-01-01')),
+        ];
+
+        yield [
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new DateNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/DateNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/DateNormalizerTest.php
@@ -13,6 +13,9 @@ use eZ\Publish\Core\FieldType\Date\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\DateNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\DateNormalizer
+ */
 final class DateNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/EmailAddressNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/EmailAddressNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\EmailAddress\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\EmailAddressNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\EmailAddressNormalizer
+ */
 final class EmailAddressNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/EmailAddressNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/EmailAddressNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\EmailAddress\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\EmailAddressNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class EmailAddressNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  string,
+     *  \eZ\Publish\Core\FieldType\EmailAddress\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            'foo@link.invalid',
+            new Value('foo@link.invalid'),
+        ];
+
+        yield [
+            '',
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new EmailAddressNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/FloatNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/FloatNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Float\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\FloatNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class FloatNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?float $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?float,
+     *  \eZ\Publish\Core\FieldType\Float\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            1.10000,
+            new Value(1.10000),
+        ];
+
+        yield [
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new FloatNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/FloatNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/FloatNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\Float\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\FloatNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\FloatNormalizer
+ */
 final class FloatNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/ISBNNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/ISBNNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\ISBN\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ISBNNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class ISBNNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  string,
+     *  \eZ\Publish\Core\FieldType\ISBN\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            '978-83-900210-1-0 ',
+            new Value('978-83-900210-1-0 '),
+        ];
+
+        yield [
+            '',
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new ISBNNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/ISBNNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/ISBNNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\ISBN\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ISBNNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ISBNNormalizer
+ */
 final class ISBNNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\ImageAsset\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ImageAssetNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class ImageAssetNormalizerTest extends AbstractDestinationContentNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?int $destinationContentId, ?string $expected, Value $value): void
+    {
+        if (null !== $destinationContentId) {
+            $this->configureDestinationContentNormalizerToReturnExpectedValue([[$destinationContentId, $expected]]);
+        }
+
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?int,
+     *  ?string,
+     *  \eZ\Publish\Core\FieldType\ImageAsset\Value,
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            1,
+            'public/var/test/1/2/3/4/5/file.invalid',
+            new Value(1),
+        ];
+
+        yield [
+            null,
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new ImageAssetNormalizer($this->destinationContentNormalizerDispatcher);
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\ImageAsset\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ImageAssetNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ImageAssetNormalizer
+ */
 final class ImageAssetNormalizerTest extends AbstractDestinationContentNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/ImageNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/ImageNormalizerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Image\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ImageNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class ImageNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?string,
+     *  \eZ\Publish\Core\FieldType\Image\Value
+     * }>
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            'public/var/test/1/2/3/4/5/file.invalid',
+            new Value(
+                [
+                    'id' => 1,
+                    'alternativeText' => 'Test image',
+                    'fileName' => 'file.invalid',
+                    'fileSize' => 123456,
+                    'uri' => 'public/var/test/1/2/3/4/5/file.invalid',
+                    'imageId' => '',
+                    'inputUri' => 'storage/file.invalid',
+                    'width' => 120,
+                    'height' => 80,
+                    'additionalData' => [],
+                ]
+            ),
+        ];
+
+        yield [
+            null,
+            new Value(
+                [
+                    'id' => null,
+                    'alternativeText' => null,
+                    'fileName' => null,
+                    'fileSize' => null,
+                    'uri' => null,
+                    'imageId' => null,
+                    'inputUri' => null,
+                    'width' => null,
+                    'height' => null,
+                    'additionalData' => [],
+                ]
+            ),
+        ];
+
+        yield [
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new ImageNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/ImageNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/ImageNormalizerTest.php
@@ -19,7 +19,6 @@ final class ImageNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**
      * @dataProvider provideDataForTestNormalize
-
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */

--- a/tests/bundle/Serializer/Normalizer/FieldType/ImageNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/ImageNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\Image\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ImageNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\ImageNormalizer
+ */
 final class ImageNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/IntegerNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/IntegerNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Integer\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\IntegerNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class IntegerNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?int $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?int,
+     *  \eZ\Publish\Core\FieldType\Integer\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            100,
+            new Value(100),
+        ];
+
+        yield [
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new IntegerNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/IntegerNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/IntegerNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\Integer\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\IntegerNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\IntegerNormalizer
+ */
 final class IntegerNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/KeywordNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/KeywordNormalizerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Keyword\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\KeywordNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class KeywordNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @param array<string> $expected
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(array $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  array<string>,
+     *  \eZ\Publish\Core\FieldType\Keyword\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            ['foo'],
+            new Value('foo'),
+        ];
+
+        yield [
+            ['foo', 'bar', 'baz'],
+            new Value(['foo', 'bar', 'baz']),
+        ];
+
+        yield [
+            [],
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new KeywordNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/KeywordNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/KeywordNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\Keyword\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\KeywordNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\KeywordNormalizer
+ */
 final class KeywordNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/MapLocationNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/MapLocationNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\MapLocation\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\MapLocationNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\MapLocationNormalizer
+ */
 final class MapLocationNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/MapLocationNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/MapLocationNormalizerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\MapLocation\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\MapLocationNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class MapLocationNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?string,
+     *  \eZ\Publish\Core\FieldType\MapLocation\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            'foo street',
+            new Value(
+                [
+                    'latitude' => 12345.11,
+                    'longitude' => 9876512.12,
+                    'address' => 'foo street',
+                ]
+            ),
+        ];
+
+        yield [
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new MapLocationNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/MediaNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/MediaNormalizerTest.php
@@ -19,7 +19,6 @@ final class MediaNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**
      * @dataProvider provideDataForTestNormalize
-
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */

--- a/tests/bundle/Serializer/Normalizer/FieldType/MediaNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/MediaNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\Media\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\MediaNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\MediaNormalizer
+ */
 final class MediaNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/MediaNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/MediaNormalizerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Media\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\MediaNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class MediaNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?string,
+     *  \eZ\Publish\Core\FieldType\Media\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            'public/var/test/1/2/3/4/5/file.invalid',
+            new Value(
+                [
+                    'hasController' => true,
+                    'autoplay' => true,
+                    'loop' => true,
+                    'height' => 500,
+                    'width' => 500,
+                    'id' => 1,
+                    'inputUri' => 'storage/file.invalid',
+                    'fileName' => 'file.invalid',
+                    'fileSize' => 123456,
+                    'mimeType' => 'image/png',
+                    'uri' => 'public/var/test/1/2/3/4/5/file.invalid',
+                ]
+            ),
+        ];
+
+        yield [
+            null,
+            new Value(
+                [
+                    'hasController' => null,
+                    'autoplay' => null,
+                    'loop' => null,
+                    'height' => null,
+                    'width' => null,
+                    'id' => null,
+                    'inputUri' => null,
+                    'fileName' => null,
+                    'fileSize' => null,
+                    'mimeType' => null,
+                    'uri' => null,
+                ]
+            ),
+        ];
+
+        yield [
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new MediaNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/RelationListNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/RelationListNormalizerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\RelationList\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RelationListNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class RelationListNormalizerTest extends AbstractDestinationContentNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @param array<int> $destinationContentIds
+     * @param array<array<int|string>> $valuesMap
+     * @param array<string> $expected
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(
+        array $destinationContentIds,
+        array $valuesMap,
+        array $expected,
+        Value $value
+    ): void {
+        if (!empty($destinationContentIds)) {
+            $this->configureDestinationContentNormalizerToReturnExpectedValue($valuesMap);
+        }
+
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  array<int>,
+     *  array<array<int|string>>,
+     *  array<string>,
+     *  \eZ\Publish\Core\FieldType\RelationList\Value,
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            [1],
+            [
+                [1, 'public/var/test/1/2/3/4/5/file.invalid'],
+            ],
+            ['public/var/test/1/2/3/4/5/file.invalid'],
+            new Value([1]),
+        ];
+
+        yield [
+            [1, 2],
+            [
+                [1, 'public/var/test/1/2/3/4/5/file.invalid'],
+                [2, 'public/var/test/6/7/8/9/file.invalid'],
+            ],
+            [
+                'public/var/test/1/2/3/4/5/file.invalid',
+                'public/var/test/6/7/8/9/file.invalid',
+            ],
+            new Value([1, 2]),
+        ];
+
+        yield [
+            [],
+            [],
+            [],
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new RelationListNormalizer($this->destinationContentNormalizerDispatcher);
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/RelationListNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/RelationListNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\RelationList\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RelationListNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RelationListNormalizer
+ */
 final class RelationListNormalizerTest extends AbstractDestinationContentNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/RelationNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/RelationNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\Relation\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RelationNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RelationNormalizer
+ */
 final class RelationNormalizerTest extends AbstractDestinationContentNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/RelationNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/RelationNormalizerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Relation\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RelationNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class RelationNormalizerTest extends AbstractDestinationContentNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?int $destinationContentId, ?string $expected, Value $value): void
+    {
+        if (null !== $destinationContentId) {
+            $this->configureDestinationContentNormalizerToReturnExpectedValue([[$destinationContentId, $expected]]);
+        }
+
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?int,
+     *  ?string,
+     *  \eZ\Publish\Core\FieldType\Relation\Value,
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            1,
+            'public/var/test/1/2/3/4/5/file.invalid',
+            new Value(1),
+        ];
+
+        yield [
+            null,
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new RelationNormalizer($this->destinationContentNormalizerDispatcher);
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/RichTextNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/RichTextNormalizerTest.php
@@ -19,7 +19,7 @@ use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerI
  */
 final class RichTextNormalizerTest extends AbstractValueNormalizerTestCase
 {
-    /** @var \EzSystems\EzPlatformRichText\eZ\RichText\Converter|mixed|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \EzSystems\EzPlatformRichText\eZ\RichText\Converter|\PHPUnit\Framework\MockObject\MockObject */
     private Converter $converter;
 
     protected function setUp(): void

--- a/tests/bundle/Serializer/Normalizer/FieldType/RichTextNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/RichTextNormalizerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use DOMDocument;
+use EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value;
+use EzSystems\EzPlatformRichText\eZ\RichText\Converter;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RichTextNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class RichTextNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /** @var \EzSystems\EzPlatformRichText\eZ\RichText\Converter|mixed|\PHPUnit\Framework\MockObject\MockObject */
+    private Converter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = $this->createMock(Converter::class);
+    }
+
+    /**
+     * @dataProvider provideDataForTestNormalize
+     * @dataProvider provideEmptyDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(
+        string $expected,
+        DOMDocument $input,
+        DOMDocument $output,
+        Value $value
+    ): void {
+        $this->converter
+            ->expects(self::once())
+            ->method('convert')
+            ->with($input)
+            ->willReturn($output);
+
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  string,
+     *  DOMDocument,
+     *  DOMDocument,
+     *  \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        $xml =
+            '<?xml version="1.0" encoding="UTF-8"?>
+            <section 
+                xmlns="http://docbook.org/ns/docbook" 
+                xmlns:xlink="http://www.w3.org/1999/xlink" 
+                xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" 
+                xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" 
+                version="5.0-variant ezpublish-1.0"
+            >
+                <para>
+                    <emphasis role="strong">You are now ready to start your project.</emphasis>
+                </para>
+            </section>';
+
+        $input = new DOMDocument();
+        $input->loadXML($xml);
+
+        $expectedOutput = '<p><strong>You are now ready to start your project.</strong></p>' . PHP_EOL;
+        $output = new DOMDocument();
+        $output->loadXML($expectedOutput);
+
+        yield [
+            $expectedOutput,
+            $input,
+            $output,
+            new Value($xml),
+        ];
+    }
+
+    /**
+     * @return iterable<array{
+     *  string,
+     *  DOMDocument,
+     *  DOMDocument,
+     *  \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value
+     * }>
+     */
+    public function provideEmptyDataForTestNormalize(): iterable
+    {
+        $xml =
+            '<?xml version="1.0" encoding="UTF-8"?>
+            <section xmlns="http://docbook.org/ns/docbook" 
+            xmlns:xlink="http://www.w3.org/1999/xlink" 
+            version="5.0-variant ezpublish-1.0"
+            />';
+
+        $emptyInput = new DOMDocument();
+        $emptyInput->loadXML($xml);
+
+        yield [
+            PHP_EOL,
+            $emptyInput,
+            new DOMDocument(),
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new RichTextNormalizer($this->converter);
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/RichTextNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/RichTextNormalizerTest.php
@@ -14,6 +14,9 @@ use EzSystems\EzPlatformRichText\eZ\RichText\Converter;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RichTextNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\RichTextNormalizer
+ */
 final class RichTextNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /** @var \EzSystems\EzPlatformRichText\eZ\RichText\Converter|mixed|\PHPUnit\Framework\MockObject\MockObject */

--- a/tests/bundle/Serializer/Normalizer/FieldType/TextBlockNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/TextBlockNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\TextBlock\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TextBlockNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class TextBlockNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  string,
+     *  \eZ\Publish\Core\FieldType\TextBlock\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+            new Value('Lorem Ipsum is simply dummy text of the printing and typesetting industry.'),
+        ];
+
+        yield [
+            '',
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new TextBlockNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/TextBlockNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/TextBlockNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\TextBlock\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TextBlockNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TextBlockNormalizer
+ */
 final class TextBlockNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/TextLineNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/TextLineNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\TextBlock\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TextLineNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TextLineNormalizer
+ */
 final class TextLineNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/TextLineNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/TextLineNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\TextBlock\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TextLineNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class TextLineNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  string,
+     *  \eZ\Publish\Core\FieldType\TextLine\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            'Lorem Ipsum',
+            new Value('Lorem Ipsum'),
+        ];
+
+        yield [
+            '',
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new TextLineNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/TimeNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/TimeNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Time\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TimeNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class TimeNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?string,
+     *  \eZ\Publish\Core\FieldType\Time\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            '09:00:00',
+            new Value(32400),
+        ];
+
+        yield [
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new TimeNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/bundle/Serializer/Normalizer/FieldType/TimeNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/TimeNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\Time\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TimeNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\TimeNormalizer
+ */
 final class TimeNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/UrlNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/UrlNormalizerTest.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\Url\Value;
 use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\UrlNormalizer;
 use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
 
+/**
+ * @covers \Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\UrlNormalizer
+ */
 final class UrlNormalizerTest extends AbstractValueNormalizerTestCase
 {
     /**

--- a/tests/bundle/Serializer/Normalizer/FieldType/UrlNormalizerTest.php
+++ b/tests/bundle/Serializer/Normalizer/FieldType/UrlNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType;
+
+use eZ\Publish\Core\FieldType\Url\Value;
+use Ibexa\Bundle\PersonalizationClient\Serializer\Normalizer\FieldType\UrlNormalizer;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+
+final class UrlNormalizerTest extends AbstractValueNormalizerTestCase
+{
+    /**
+     * @dataProvider provideDataForTestNormalize
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testNormalizer(?string $expected, Value $value): void
+    {
+        $this->testNormalize($expected, $value);
+    }
+
+    /**
+     * @return iterable<array{
+     *  ?string,
+     *  \eZ\Publish\Core\FieldType\Url\Value
+     * }>
+     */
+    public function provideDataForTestNormalize(): iterable
+    {
+        yield [
+            'link.invalid',
+            new Value('link.invalid', 'foo'),
+        ];
+
+        yield [
+            null,
+            new Value(),
+        ];
+    }
+
+    protected function getNormalizer(): ValueNormalizerInterface
+    {
+        return new UrlNormalizer();
+    }
+
+    protected function getValue(): Value
+    {
+        return new Value();
+    }
+}

--- a/tests/lib/FieldType/DestinationContentNormalizerDispatcherTest.php
+++ b/tests/lib/FieldType/DestinationContentNormalizerDispatcherTest.php
@@ -19,6 +19,9 @@ use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcher
 use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcher
+ */
 final class DestinationContentNormalizerDispatcherTest extends TestCase
 {
     private DestinationContentNormalizerDispatcherInterface $destinationContentNormalizerDispatcher;

--- a/tests/lib/FieldType/DestinationContentNormalizerDispatcherTest.php
+++ b/tests/lib/FieldType/DestinationContentNormalizerDispatcherTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\PersonalizationClient\FieldType;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\FieldType\Null\Value as NullValue;
+use eZ\Publish\Core\FieldType\Value;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\DestinationValueAwareInterface;
+use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcher;
+use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcherInterface;
+use PHPUnit\Framework\TestCase;
+
+final class DestinationContentNormalizerDispatcherTest extends TestCase
+{
+    private DestinationContentNormalizerDispatcherInterface $destinationContentNormalizerDispatcher;
+
+    /** @var \Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\DestinationValueAwareInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private DestinationValueAwareInterface $valueNormalizer;
+
+    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
+    private ContentService $contentService;
+
+    /** @var \eZ\Publish\API\Repository\Repository|\PHPUnit\Framework\MockObject\MockObject */
+    private Repository $repository;
+
+    protected function setUp(): void
+    {
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->repository = $this->createMock(Repository::class);
+        $this->valueNormalizer = $this->createMock(DestinationValueAwareInterface::class);
+        $this->destinationContentNormalizerDispatcher = new DestinationContentNormalizerDispatcher(
+            [
+                $this->valueNormalizer,
+            ],
+            $this->contentService,
+            $this->repository
+        );
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testDispatchReturnNormalizedValue(): void
+    {
+        $value = $this->getFieldValue(12345);
+
+        $this->configureContentServiceToReturnDestinationContent(12345);
+        $this->configureValueNormalizerToReturnIsSupportedNormalizer($value, true);
+        $this->configureValueNormalizerToReturnNormalizedValue($value, 12345);
+
+        self::assertEquals(
+            12345,
+            $this->destinationContentNormalizerDispatcher->dispatch(123)
+        );
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testDispatchReturnNullWhenSupportedNormalizerNotFound(): void
+    {
+        $value = $this->getFieldValue(12345);
+
+        $this->configureContentServiceToReturnDestinationContent(12345);
+        $this->configureValueNormalizerToReturnIsSupportedNormalizer($value, false);
+
+        self::assertNull($this->destinationContentNormalizerDispatcher->dispatch(123));
+    }
+
+    private function configureContentServiceToReturnDestinationContent(int $fieldValue): void
+    {
+        $destinationContent = new Content(
+            [
+                'internalFields' => [
+                    new Field(
+                        [
+                            'id' => 1,
+                            'fieldDefIdentifier' => 'foo',
+                            'value' => $this->getFieldValue($fieldValue),
+                            'languageCode' => 'pl',
+                            'fieldTypeIdentifier' => 'foo',
+                        ]
+                    ),
+                ],
+            ]
+        );
+
+        $this->repository
+            ->expects(self::atLeastOnce())
+            ->method('sudo')
+            ->with(static function () {})
+            ->willReturn($destinationContent);
+    }
+
+    private function getFieldValue(?int $value = null): Value
+    {
+        return new NullValue($value);
+    }
+
+    private function configureValueNormalizerToReturnIsSupportedNormalizer(
+        Value $value,
+        bool $isSupported
+    ): void {
+        $this->valueNormalizer
+            ->expects(self::atLeastOnce())
+            ->method('supportsValue')
+            ->with($value)
+            ->willReturn($isSupported);
+    }
+
+    /**
+     * @param scalar $normalizedValue
+     */
+    private function configureValueNormalizerToReturnNormalizedValue(
+        Value $value,
+        $normalizedValue
+    ): void {
+        $this->valueNormalizer
+            ->expects(self::atLeastOnce())
+            ->method('normalize')
+            ->with($value)
+            ->willReturn($normalizedValue);
+    }
+}

--- a/tests/lib/FieldType/DestinationContentNormalizerDispatcherTest.php
+++ b/tests/lib/FieldType/DestinationContentNormalizerDispatcherTest.php
@@ -41,11 +41,11 @@ final class DestinationContentNormalizerDispatcherTest extends TestCase
         $this->repository = $this->createMock(Repository::class);
         $this->valueNormalizer = $this->createMock(DestinationValueAwareInterface::class);
         $this->destinationContentNormalizerDispatcher = new DestinationContentNormalizerDispatcher(
+            $this->contentService,
+            $this->repository,
             [
                 $this->valueNormalizer,
             ],
-            $this->contentService,
-            $this->repository
         );
     }
 

--- a/tests/lib/FieldType/ValueNormalizerDispatcherTest.php
+++ b/tests/lib/FieldType/ValueNormalizerDispatcherTest.php
@@ -16,6 +16,9 @@ use Ibexa\PersonalizationClient\FieldType\ValueNormalizerDispatcher;
 use Ibexa\PersonalizationClient\FieldType\ValueNormalizerDispatcherInterface;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Ibexa\PersonalizationClient\FieldType\ValueNormalizerDispatcher
+ */
 final class ValueNormalizerDispatcherTest extends TestCase
 {
     private ValueNormalizerDispatcherInterface $valueNormalizerDispatcher;

--- a/tests/lib/FieldType/ValueNormalizerDispatcherTest.php
+++ b/tests/lib/FieldType/ValueNormalizerDispatcherTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\PersonalizationClient\FieldType;
+
+use eZ\Publish\Core\FieldType\Null\Value as NullValue;
+use eZ\Publish\Core\FieldType\Value;
+use Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface;
+use Ibexa\PersonalizationClient\Exception\ValueNormalizerNotFoundException;
+use Ibexa\PersonalizationClient\FieldType\ValueNormalizerDispatcher;
+use Ibexa\PersonalizationClient\FieldType\ValueNormalizerDispatcherInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ValueNormalizerDispatcherTest extends TestCase
+{
+    private ValueNormalizerDispatcherInterface $valueNormalizerDispatcher;
+
+    /** @var \Ibexa\Contracts\PersonalizationClient\Serializer\Normalizer\ValueNormalizerInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private ValueNormalizerInterface $valueNormalizer;
+
+    protected function setUp(): void
+    {
+        $this->valueNormalizer = $this->createMock(ValueNormalizerInterface::class);
+        $this->valueNormalizerDispatcher = new ValueNormalizerDispatcher(
+            [
+                $this->valueNormalizer,
+            ]
+        );
+    }
+
+    public function testDispatch(): void
+    {
+        $nullValue = $this->getFieldValue(12345);
+        $this->configureValueNormalizerToReturnIsSupportedNormalizer($nullValue, true);
+        $this->configureValueNormalizerToReturnNormalizedValue($nullValue, 12345);
+
+        self::assertEquals(
+            12345,
+            $this->valueNormalizerDispatcher->dispatch($nullValue)
+        );
+    }
+
+    public function testSupportNormalizerReturnTrueWhenSupportedValueNormalizerFound(): void
+    {
+        $nullValue = $this->getFieldValue();
+
+        $this->configureValueNormalizerToReturnIsSupportedNormalizer($nullValue, true);
+        self::assertTrue($this->valueNormalizerDispatcher->supportsNormalizer($nullValue));
+    }
+
+    public function testSupportNormalizerReturnFalseWhenSupportedValueNormalizerNotFound(): void
+    {
+        $nullValue = $this->getFieldValue();
+
+        $this->configureValueNormalizerToReturnIsSupportedNormalizer($nullValue, false);
+        self::assertFalse($this->valueNormalizerDispatcher->supportsNormalizer($nullValue));
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testThrowValueNormalizerNotFoundException(): void
+    {
+        $nullValue = $this->getFieldValue();
+
+        $this->expectException(ValueNormalizerNotFoundException::class);
+        $this->expectExceptionMessage(sprintf(
+            'ValueNormalizer not found for field type value: %s.',
+            NullValue::class
+        ));
+
+        $this->valueNormalizerDispatcher->dispatch($nullValue);
+    }
+
+    private function getFieldValue(?int $value = null): Value
+    {
+        return new NullValue($value);
+    }
+
+    private function configureValueNormalizerToReturnIsSupportedNormalizer(
+        Value $value,
+        bool $isSupported
+    ): void {
+        $this->valueNormalizer
+            ->expects(self::atLeastOnce())
+            ->method('supportsValue')
+            ->with($value)
+            ->willReturn($isSupported);
+    }
+
+    /**
+     * @param scalar $normalizedValue
+     */
+    private function configureValueNormalizerToReturnNormalizedValue(
+        Value $value,
+        $normalizedValue
+    ): void {
+        $this->valueNormalizer
+            ->expects(self::atLeastOnce())
+            ->method('normalize')
+            ->with($value)
+            ->willReturn($normalizedValue);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-746](https://issues.ibexa.co/browse/IBX-746)
| **Type**                                   | feature
| **Target Ibexa DXP version** | `v4.0` 
| **BC breaks**                          | no
| **Doc needed**                       | yes

This PR introduces basic set of Normalizers for `eZ\Publish\SPI\FieldType\Value` objects. Each supported `FieldType` has own Normalizer what makes this solution more clearer, flexible, extendable and testable. Normalizers are necessary during the export process to get value that will be added to export file.
Not all FieldTypes are supported. We have selected those that are necessary and provide business value.

There are two different types of Contracts: 
- `ValueNormalizerInterface` - basic contract for `eZ\Publish\SPI\FieldType\Value` which include below methods: 

**To return normalized value:**
```php
    /**
     * @return array<scalar|null>|scalar|null
     *
     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
     */
    public function normalize(Value $value);
```
**To check if normalizer supports given  `eZ\Publish\SPI\FieldType\Value` objects:**
```php
    public function supportsValue(Value $value): bool;
```

- `DestinationValueAwareInterface` - contract for `eZ\Publish\SPI\FieldType\Value` which extending `ValueNormalizerInterface` and pointing to destination content e.g.: `ImageAsset`, `Relation`, `RelationList`

There are also added two Dispatchers: 

- `ValueNormalizerDispatcher` - dispatches supported `ValueNormalizer`. There is also added method `supportsNormalizer` to check If there is added Normalizer for Value. Values for not supported FieldTypes should not be included in export file.

- `DestinationContentNormalizerDispatcher` - dispatches supported Normalizers which implements `DestinationValueAwareInterface`.

Both Dispatchers looks similar but have different roles. When it comes to get normalized value for destination content `DestinationContentNormalizerDispatcher` fetch destination content and returns value only for field which can be a destination value.  

To explain how it works let see on `ImageNormalizer` which implements `DestinationValueAwareInterface`. Users can use images by 4 different FieldTypes:

- Image
- ImageAsset
- Relation
- RelationList

Image uri is stored in `eZ\Publish\Core\FieldType\Image\Value::$uri`. When one of destination content fields is used then content object contains fields with values: 

1. `eZ\Publish\Core\FieldType\TextLine\Value`
2. `EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value`
3. `eZ\Publish\Core\FieldType\Image\Value`

Destination value will be normalized value from `eZ\Publish\Core\FieldType\Image\Value`. Rest of the values are useless. 

All values included in export files should have business value that's why only Image FieldType is set as destination value.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/php-dev`).
