### PR TITLE
IBX-746: Fixed properties and variables names

### DIFF
--- a/src/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/ImageAssetNormalizer.php
@@ -16,11 +16,11 @@ use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcher
 
 final class ImageAssetNormalizer implements ValueNormalizerInterface
 {
-    private DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer;
+    private DestinationContentNormalizerDispatcherInterface $destinationContentNormalizerDispatcher;
 
-    public function __construct(DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer)
+    public function __construct(DestinationContentNormalizerDispatcherInterface $destinationContentNormalizerDispatcher)
     {
-        $this->destinationContentNormalizer = $destinationContentNormalizer;
+        $this->destinationContentNormalizerDispatcher = $destinationContentNormalizerDispatcher;
     }
 
     public function normalize(Value $value): ?string
@@ -31,7 +31,7 @@ final class ImageAssetNormalizer implements ValueNormalizerInterface
 
         $destinationContentId = $value->destinationContentId;
         if (null !== $destinationContentId) {
-            $imageUri = $this->destinationContentNormalizer->dispatch((int) $destinationContentId);
+            $imageUri = $this->destinationContentNormalizerDispatcher->dispatch((int) $destinationContentId);
             if (is_string($imageUri)) {
                 return $imageUri;
             }

--- a/src/bundle/Serializer/Normalizer/FieldType/RelationListNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/RelationListNormalizer.php
@@ -16,11 +16,11 @@ use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcher
 
 final class RelationListNormalizer implements ValueNormalizerInterface
 {
-    private DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer;
+    private DestinationContentNormalizerDispatcherInterface $destinationContentNormalizerDispatcher;
 
-    public function __construct(DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer)
+    public function __construct(DestinationContentNormalizerDispatcherInterface $destinationContentNormalizerDispatcher)
     {
-        $this->destinationContentNormalizer = $destinationContentNormalizer;
+        $this->destinationContentNormalizerDispatcher = $destinationContentNormalizerDispatcher;
     }
 
     /**
@@ -34,15 +34,15 @@ final class RelationListNormalizer implements ValueNormalizerInterface
             throw new InvalidArgumentType('$value', RelationListValue::class);
         }
 
-        $fields = [];
+        $values = [];
         foreach ($value->destinationContentIds as $destinationContentId) {
-            $normalizedValue = $this->destinationContentNormalizer->dispatch($destinationContentId);
+            $normalizedValue = $this->destinationContentNormalizerDispatcher->dispatch($destinationContentId);
             if (null !== $normalizedValue) {
-                $fields[] = $normalizedValue;
+                $values[] = $normalizedValue;
             }
         }
 
-        return $fields;
+        return $values;
     }
 
     public function supportsValue(Value $value): bool

--- a/src/bundle/Serializer/Normalizer/FieldType/RelationNormalizer.php
+++ b/src/bundle/Serializer/Normalizer/FieldType/RelationNormalizer.php
@@ -16,11 +16,11 @@ use Ibexa\PersonalizationClient\FieldType\DestinationContentNormalizerDispatcher
 
 final class RelationNormalizer implements ValueNormalizerInterface
 {
-    private DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer;
+    private DestinationContentNormalizerDispatcherInterface $destinationContentNormalizerDispatcher;
 
-    public function __construct(DestinationContentNormalizerDispatcherInterface $destinationContentNormalizer)
+    public function __construct(DestinationContentNormalizerDispatcherInterface $destinationContentNormalizerDispatcher)
     {
-        $this->destinationContentNormalizer = $destinationContentNormalizer;
+        $this->destinationContentNormalizerDispatcher = $destinationContentNormalizerDispatcher;
     }
 
     public function normalize(Value $value)
@@ -31,7 +31,7 @@ final class RelationNormalizer implements ValueNormalizerInterface
 
         $destinationContentId = $value->destinationContentId;
         if (null !== $destinationContentId) {
-            return $this->destinationContentNormalizer->dispatch((int) $destinationContentId);
+            return $this->destinationContentNormalizerDispatcher->dispatch((int) $destinationContentId);
         }
 
         return null;


### PR DESCRIPTION
This PR fixes property name to be more consistent: `$destinationContentNormalizer` to `$destinationContentNormalizerDispatcher` and `$fields`  to `$values`  